### PR TITLE
fix: Broken UglifyJs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ additions.
 - [API Documentation](#api-documentation)
 - [Usage Example](#usage-example)
 - [Web Application Developer Tools](#web-application-developer-tools)
-- [Buttplug and Uglify](@buttplug-and-uglify)
+- [Buttplug and Uglify](#buttplug-and-uglify)
 - [Helper Libraries](#helper-libraries)
 - [Applications Using Buttplug-JS](#applications-using-buttplug-js)
 - [License](#license)


### PR DESCRIPTION
The link was resolving off to a non-existing file rather than being a reference to a location in the same page.