### PR TITLE
 feat: Adding multiple device protocols

### DIFF
--- a/packages/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/packages/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -147,15 +147,33 @@ protocols:
       names:
         - LVS-*
       services:
-        0000fff0-0000-1000-8000-00805f9b34fb: null
-        6e400001-b5a3-f393-e0a9-e50e24dcca9e: null
-        50300001-0024-4bd4-bbd5-a6920e4c5653: null
-        57300001-0023-4bd4-bbd5-a6920e4c5653: null
-        5a300001-0024-4bd4-bbd5-a6920e4c5653: null
-        50300001-0023-4bd4-bbd5-a6920e4c5653: null
-        53300001-0023-4bd4-bbd5-a6920e4c5653: null
-        5a300001-0023-4bd4-bbd5-a6920e4c5653: null
-        4f300001-0023-4bd4-bbd5-a6920e4c5653: null
+        0000fff0-0000-1000-8000-00805f9b34fb:
+          tx: 0000fff2-0000-1000-8000-00805f9b34fb
+          rx: 0000fff1-0000-1000-8000-00805f9b34fb
+        6e400001-b5a3-f393-e0a9-e50e24dcca9e:
+          tx: 6e400002-b5a3-f393-e0a9-e50e24dcca9e
+          rx: 6e400003-b5a3-f393-e0a9-e50e24dcca9e
+        50300001-0024-4bd4-bbd5-a6920e4c5653:
+          tx: 50300002-0024-4bd4-bbd5-a6920e4c5653
+          rx: 50300003-0024-4bd4-bbd5-a6920e4c5653
+        57300001-0023-4bd4-bbd5-a6920e4c5653:
+          tx: 57300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 57300003-0023-4bd4-bbd5-a6920e4c5653
+        5a300001-0024-4bd4-bbd5-a6920e4c5653:
+          tx: 5a300002-0024-4bd4-bbd5-a6920e4c5653
+          rx: 5a300003-0024-4bd4-bbd5-a6920e4c5653
+        50300001-0023-4bd4-bbd5-a6920e4c5653:
+          tx: 50300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 50300003-0023-4bd4-bbd5-a6920e4c5653
+        53300001-0023-4bd4-bbd5-a6920e4c5653:
+          tx: 53300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 53300003-0023-4bd4-bbd5-a6920e4c5653
+        5a300001-0023-4bd4-bbd5-a6920e4c5653:
+          tx: 5a300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 5a300003-0023-4bd4-bbd5-a6920e4c5653
+        4f300001-0023-4bd4-bbd5-a6920e4c5653:
+          tx: 4f300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 4f300003-0023-4bd4-bbd5-a6920e4c5653
   xinput:
     # This will actually be ANY gamepad that supports XInput. XInput
     # is its own connector type, so we don't have any special
@@ -167,13 +185,23 @@ protocols:
   libo:
       btle:
         names:
-          - PiPiJing
+          - PiPiJing # Whale/ELLE - Shock Egg
+          - XiaoLu # Lottie - Rabbit
+          - LuXiaoHan # LuLu - Egg
+          - SuoYinQiu # Karen - Kegel
+          - BaiHu # LaLa - Suction Rabbit
+          - MonsterPub # Sistalk MonsterPub (all 6?)
         services:
           # Write Service
           00006000-0000-1000-8000-00805f9b34fb:
-            txshock: 00006001-0000-1000-8000-00805f9b34fb
-            txvibrate: 00006002-0000-1000-8000-00805f9b34fb
+            tx: 00006001-0000-1000-8000-00805f9b34fb
+            txmode: 00006002-0000-1000-8000-00805f9b34fb
           # Read Service (battery)
+          # 00006050-0000-1000-8000-00805f9b34fb:
+          #   battery: 00006051-0000-1000-8000-00805f9b34fb
+          # 00006070-0000-1000-8000-00805f9b34fb:
+          #   battery: 00006071-0000-1000-8000-00805f9b34fb
+          # Read Service (pressue)
           # 00006050-0000-1000-8000-00805f9b34fb:
           #   battery: 00006051-0000-1000-8000-00805f9b34fb
   magic-motion:
@@ -250,7 +278,8 @@ protocols:
       names:
         - Youcups
       services:
-        0000fee9-0000-1000-8000-00805f9b34fb: null
+        0000fee9-0000-1000-8000-00805f9b34fb:
+          tx: d44bc439-abfd-45a2-b575-925416129600
   cueme:
     btle:
       names:
@@ -332,6 +361,14 @@ protocols:
       services:
         0000fff0-0000-1000-8000-00805f9b34fb:
           tx: 0000fff6-0000-1000-8000-00805f9b34fb
+  prettylove:
+    btle:
+      names:
+        - Aogu BLE *
+      services:
+        0000FFE5-0000-1000-8000-00805f9b34fb:
+          tx: 0000FFE9-0000-1000-8000-00805f9b34fb
+          rx: 0000FFE2-0000-1000-8000-00805f9b34fb
   # nintendo-joycon:
   #   names:
   #     en-us: Nintendo Joycon

--- a/packages/buttplug/src/devices/configuration/DeviceConfigurationManager.ts
+++ b/packages/buttplug/src/devices/configuration/DeviceConfigurationManager.ts
@@ -14,6 +14,9 @@ import { HIDProtocolConfiguration } from "./HIDProtocolConfiguration";
 import { Lovense } from "../protocols/Lovense";
 import { WeVibe } from "../protocols/WeVibe";
 import { VorzeA10Cyclone } from "../protocols/VorzeA10Cyclone";
+import { MagicMotion } from "../protocols/MagicMotion";
+import { LiBo } from "../protocols/LiBo";
+import { Youcups } from "../protocols/Youcups";
 import { Maxpro } from "../protocols/Maxpro";
 import { FleshlightLaunch } from "../protocols/FleshlightLaunch";
 import { ButtplugDeviceProtocolType } from "../ButtplugDeviceProtocol";
@@ -49,10 +52,13 @@ export class DeviceConfigurationManager {
     this._configObject = aConfigObject;
     this._protocols.set("lovense", Lovense);
     this._protocols.set("wevibe", WeVibe);
-    this._protocols.set("vorzesa", VorzeA10Cyclone);
+    this._protocols.set("vorze-sa", VorzeA10Cyclone);
+    this._protocols.set("magic-motion", MagicMotion);
     this._protocols.set("maxpro", Maxpro);
     this._protocols.set("kiiroo-v2", FleshlightLaunch);
     this._protocols.set("youou", Youou);
+    this._protocols.set("youcups", Youcups);
+    this._protocols.set("libo", LiBo);
     // Parse our configuration object last, as we need to add device protocols
     // first.
     this.ParseConfig();

--- a/packages/buttplug/src/devices/protocols/LiBo.ts
+++ b/packages/buttplug/src/devices/protocols/LiBo.ts
@@ -1,0 +1,156 @@
+/*!
+ * Buttplug JS Source Code File - Visit https://buttplug.io for more info about
+ * the project. Licensed under the BSD 3-Clause license. See LICENSE file in the
+ * project root for full license information.
+ *
+ * @copyright Copyright (c) Nonpolynomial Labs LLC. All rights reserved.
+ */
+
+import * as Messages from "../../core/Messages";
+import { ButtplugDeviceException } from "../../core/Exceptions";
+import { ButtplugDeviceProtocol } from "../ButtplugDeviceProtocol";
+import { IButtplugDeviceImpl } from "../IButtplugDeviceImpl";
+import {Endpoints} from "../Endpoints";
+import {ButtplugDeviceWriteOptions} from "../ButtplugDeviceWriteOptions";
+
+class LiBoType {
+  public Name: string = "Lottie";
+  public VibeCount: number = 1;
+  public VibeOrder: number[] = [ 0, 1 ];
+}
+
+export class LiBo extends ButtplugDeviceProtocol {
+
+  private static DevInfos = new Map<string, LiBoType>([
+    [
+      "PiPiJing",
+      Object.assign(new LiBoType(), {
+        Name: "Elle",
+        VibeCount: 2, // Shock as vibe
+        VibeOrder: [ 1, 0 ],
+      }),
+    ],
+    [
+      "XiaoLu",
+      Object.assign(new LiBoType(), {
+        Name: "Lottie",
+        VibeCount: 1,
+      }),
+    ],
+    [
+      "SuoYinQiu",
+      Object.assign(new LiBoType(), {
+        Name: "Karen",
+        VibeCount: 0,
+      }),
+    ],
+    [
+      "BaiHu",
+      Object.assign(new LiBoType(), {
+        Name: "LaLa",
+        VibeCount: 2, // Suction as vibe
+      }),
+    ],
+    [
+      "LuXiaoHan",
+      Object.assign(new LiBoType(), {
+        Name: "LuLu",
+        VibeCount: 1,
+      }),
+    ],
+    [
+      "MonsterPub",
+      Object.assign(new LiBoType(), {
+        Name: "MonsterPub",
+        VibeCount: 1,
+      }),
+    ],
+  ]);
+
+  private _devInfo: LiBoType = new LiBoType();
+  private _hasRunCommand = false;
+  private _vibratorSpeed = [ 0.0, 0.0 ];
+
+  public constructor(aDeviceImpl: IButtplugDeviceImpl) {
+    super("LiBo", aDeviceImpl);
+
+    const tmpType = LiBo.DevInfos.get(aDeviceImpl.Name);
+    if (tmpType !== undefined) {
+      this._devInfo = tmpType;
+      this._name = `LiBo ${this._devInfo.Name}`;
+    }
+
+    this.MsgFuncs.set(Messages.StopDeviceCmd, this.HandleStopDeviceCmd);
+    this.MsgFuncs.set(Messages.SingleMotorVibrateCmd, this.HandleSingleMotorVibrateCmd);
+    this.MsgFuncs.set(Messages.VibrateCmd, this.HandleVibrateCmd);
+  }
+
+  public get MessageSpecifications(): object {
+    return {
+      VibrateCmd: { FeatureCount: this._devInfo.VibeCount },
+      SingleMotorVibrateCmd: {},
+      StopDeviceCmd: {},
+    };
+  }
+
+  private HandleVibrateCmd = async (aMsg: Messages.VibrateCmd): Promise<Messages.ButtplugMessage> => {
+    if (aMsg.Speeds.length < 1 || aMsg.Speeds.length > this._devInfo.VibeCount) {
+      throw new ButtplugDeviceException(`Libo devices require VibrateCmd to have at most ` +
+                                        `${this._devInfo.VibeCount} speed commands, ${aMsg.Speeds.length} sent.`,
+                                        aMsg.Id);
+    }
+
+    const changed = [ false, false ];
+
+    for (const cmd of aMsg.Speeds) {
+      if (!(Math.abs(cmd.Speed - this._vibratorSpeed[cmd.Index]) > 0.001)) {
+        continue;
+      }
+
+      changed[cmd.Index] = true;
+      this._vibratorSpeed[cmd.Index] = cmd.Speed;
+    }
+
+    if (changed[this._devInfo.VibeOrder[0]] || !this._hasRunCommand) {
+      let ep = Endpoints.Tx;
+      if (this._devInfo.VibeCount === 1 && Math.ceil(this._vibratorSpeed[this._devInfo.VibeOrder[0]] * 0x64) === 0) {
+        ep = Endpoints.TxMode;
+      }
+
+      // Map a 0 - 100% value to a 0 - 0x64 value since 0 * x == 0 this will turn off the vibe if
+      // speed is 0.00
+      await this._device.WriteValue( Buffer.from([ Math.ceil(this._vibratorSpeed[this._devInfo.VibeOrder[0]] * 0x64) ]),
+      new ButtplugDeviceWriteOptions( { Endpoint: ep }));
+    }
+
+    if (this._devInfo.VibeCount < 2 || (!changed[this._devInfo.VibeOrder[1]] && this._hasRunCommand) ) {
+      if (this._devInfo.VibeCount < 2) {
+        this._hasRunCommand = true;
+      }
+
+      return new Messages.Ok(aMsg.Id);
+    }
+
+    this._hasRunCommand = true;
+
+    // Map a 0 - 100% value to a 0 - 3 value since 0 * x == 0 this will turn off the vibe if
+    // speed is 0.00
+    await this._device.WriteValue( Buffer.from([ Math.ceil(this._vibratorSpeed[this._devInfo.VibeOrder[1]] * 3) ]),
+    new ButtplugDeviceWriteOptions( { Endpoint: Endpoints.TxMode }));
+
+    return new Messages.Ok(aMsg.Id);
+  }
+
+  private HandleStopDeviceCmd = async (aMsg: Messages.StopDeviceCmd): Promise<Messages.ButtplugMessage> => {
+    return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(0, aMsg.DeviceIndex, aMsg.Id));
+  }
+
+  private HandleSingleMotorVibrateCmd =
+    async (aMsg: Messages.SingleMotorVibrateCmd): Promise<Messages.ButtplugMessage> => {
+      const speeds: Messages.SpeedSubcommand[] = [];
+      for (let i = 0; i < this._devInfo.VibeCount; i++) {
+        speeds.push(new Messages.SpeedSubcommand(i, aMsg.Speed));
+      }
+      return await this.HandleVibrateCmd(new Messages.VibrateCmd(speeds, aMsg.DeviceIndex, aMsg.Id));
+    }
+}

--- a/packages/buttplug/src/devices/protocols/MagicMotion.ts
+++ b/packages/buttplug/src/devices/protocols/MagicMotion.ts
@@ -1,0 +1,200 @@
+/*!
+ * Buttplug JS Source Code File - Visit https://buttplug.io for more info about
+ * the project. Licensed under the BSD 3-Clause license. See LICENSE file in the
+ * project root for full license information.
+ *
+ * @copyright Copyright (c) Nonpolynomial Labs LLC. All rights reserved.
+ */
+
+import * as Messages from "../../core/Messages";
+import { ButtplugDeviceException } from "../../core/Exceptions";
+import { ButtplugDeviceProtocol } from "../ButtplugDeviceProtocol";
+import { IButtplugDeviceImpl } from "../IButtplugDeviceImpl";
+
+class MagicMotionType {
+  public Brand: string = "MagicMotion";
+  public Name: string = "Smart Mini Vibe";
+  public VibeCount: number = 1;
+  public Protocol: number = 1;
+  public MaxSpeed: number = 0x64;
+}
+
+export class MagicMotion extends ButtplugDeviceProtocol {
+
+  private static DevInfos = new Map<string, MagicMotionType>([
+    [
+      "Smart Mini Vibe",
+      Object.assign(new MagicMotionType(),
+      {
+        Brand: "MagicMotion",
+        Name: "Smart Mini Vibe",
+        VibeCount: 1,
+        Protocol: 1,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Flamingo",
+      Object.assign(new MagicMotionType(),
+      {
+        Brand: "MagicMotion",
+        Name: "Flamingo",
+        VibeCount: 1,
+        Protocol: 1,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Magic Cell",
+      Object.assign(new MagicMotionType(),
+      {
+        // ToDo: has accelerometer
+        Brand: "MagicMotion",
+        Name: "Dante/Candy",
+        VibeCount: 1,
+        Protocol: 1,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Eidolon",
+      Object.assign(new MagicMotionType(),
+      {
+        Brand : "MagicMotion",
+        Name: "Eidolon",
+        VibeCount: 2,
+        Protocol: 2,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Smart Bean",
+      Object.assign(new MagicMotionType(),
+      {
+        // ToDo: Master has pressure sensor, Twins does not
+        Brand: "MagicMotion",
+        Name: "Kegel",
+        VibeCount: 1,
+        Protocol: 1,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Magic Wand",
+      Object.assign(new MagicMotionType(),
+      {
+        // ToDo: Wand has temperature sensor and heater
+        Brand: "MagicMotion",
+        Name: "Wand",
+        VibeCount: 1,
+        Protocol: 1,
+        MaxSpeed: 0x64,
+      }),
+    ],
+    [
+      "Krush",
+      Object.assign(new MagicMotionType(),
+      {
+        // ToDo: Receive squeeze sensor packets & capture exact motor values
+        Brand: "LoveLife",
+        Name: "Krush",
+        VibeCount: 1,
+        Protocol: 3,
+        MaxSpeed: 0x4d,
+      }),
+    ],
+  ]);
+
+  private _devInfo: MagicMotionType = new MagicMotionType();
+  private _hasRunCommand = false;
+  private _vibratorSpeed = [ 0.0, 0.0 ];
+
+  public constructor(aDeviceImpl: IButtplugDeviceImpl) {
+    super("MagicMotion", aDeviceImpl);
+
+    const tmpType = MagicMotion.DevInfos.get(aDeviceImpl.Name);
+    if (tmpType !== undefined) {
+      this._devInfo = tmpType;
+      this._name = `${this._devInfo.Brand} ${this._devInfo.Name}`;
+    }
+
+    this.MsgFuncs.set(Messages.StopDeviceCmd, this.HandleStopDeviceCmd);
+    this.MsgFuncs.set(Messages.SingleMotorVibrateCmd, this.HandleSingleMotorVibrateCmd);
+    this.MsgFuncs.set(Messages.VibrateCmd, this.HandleVibrateCmd);
+  }
+
+  public get MessageSpecifications(): object {
+    return {
+      VibrateCmd: { FeatureCount: this._devInfo.VibeCount },
+      SingleMotorVibrateCmd: {},
+      StopDeviceCmd: {},
+    };
+  }
+
+  private HandleVibrateCmd = async (aMsg: Messages.VibrateCmd): Promise<Messages.ButtplugMessage> => {
+    if (aMsg.Speeds.length < 1 || aMsg.Speeds.length > this._devInfo.VibeCount) {
+      throw new ButtplugDeviceException(`MagicMotionn devices require VibrateCmd at most ` +
+                                        `${this._devInfo.VibeCount} speed commands, ${aMsg.Speeds.length} sent.`,
+                                        aMsg.Id);
+    }
+
+    let changed = false;
+    for (const cmd of aMsg.Speeds) {
+      if (!(Math.abs(cmd.Speed - this._vibratorSpeed[cmd.Index]) > 0.001)) {
+        continue;
+      }
+
+      changed = true;
+      this._vibratorSpeed[cmd.Index] = cmd.Speed;
+    }
+
+    if (!changed && this._hasRunCommand) {
+      return new Messages.Ok(aMsg.Id);
+    }
+
+    let data: Buffer;
+    switch (this._devInfo.Protocol) {
+      case 1:
+        data = Buffer.from([ 0x0b, 0xff, 0x04, 0x0a, 0x32, 0x32, 0x00, 0x04, 0x08, 0x00, 0x64, 0x00 ]);
+        data[9] = Math.round(this._vibratorSpeed[0] * this._devInfo.MaxSpeed);
+        break;
+
+      case 2:
+        data = Buffer.from([ 0x10, 0xff, 0x04, 0x0a, 0x32, 0x0a, 0x00, 0x04, 0x08, 0x00, 0x64, 0x00,
+                             0x04, 0x08, 0x00, 0x64, 0x01 ]);
+        data[9] = Math.round(this._vibratorSpeed[0] * this._devInfo.MaxSpeed);
+
+        if (this._devInfo.VibeCount >= 2) {
+          data[14] = Math.round(this._vibratorSpeed[1] * this._devInfo.MaxSpeed);
+        }
+
+        break;
+
+      case 3:
+        data = Buffer.from([ 0x0b, 0xff, 0x04, 0x0a, 0x46, 0x46, 0x00, 0x04, 0x08, 0x00, 0x64, 0x00 ]);
+        data[9] = Math.round(this._vibratorSpeed[0] * this._devInfo.MaxSpeed);
+        break;
+
+      default:
+        throw new ButtplugDeviceException("Unknown communication protocol.");
+    }
+
+    this._hasRunCommand = true;
+
+    await this._device.WriteValue(data);
+    return new Messages.Ok(aMsg.Id);
+  }
+
+  private HandleStopDeviceCmd = async (aMsg: Messages.StopDeviceCmd): Promise<Messages.ButtplugMessage> => {
+    return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(0, aMsg.DeviceIndex, aMsg.Id));
+  }
+
+  private HandleSingleMotorVibrateCmd =
+    async (aMsg: Messages.SingleMotorVibrateCmd): Promise<Messages.ButtplugMessage> => {
+      const speeds: Messages.SpeedSubcommand[] = [];
+      for (let i = 0; i < this._devInfo.VibeCount; i++) {
+        speeds.push(new Messages.SpeedSubcommand(i, aMsg.Speed));
+      }
+      return await this.HandleVibrateCmd(new Messages.VibrateCmd(speeds, aMsg.DeviceIndex, aMsg.Id));
+    }
+}

--- a/packages/buttplug/src/devices/protocols/VorzeA10Cyclone.ts
+++ b/packages/buttplug/src/devices/protocols/VorzeA10Cyclone.ts
@@ -11,18 +11,80 @@ import { ButtplugDeviceException } from "../../core/Exceptions";
 import { ButtplugDeviceProtocol } from "../ButtplugDeviceProtocol";
 import { IButtplugDeviceImpl } from "../IButtplugDeviceImpl";
 
+enum VorzeCommand {
+  Rotate = 1,
+  Vibrate = 3,
+}
+
+class VorzeType {
+  public Name: string = "Vorze A10 Cyclone SA";
+  public CommandType: VorzeCommand = VorzeCommand.Rotate;
+  public DeviceType: number = 1;
+}
+
 export class VorzeA10Cyclone extends ButtplugDeviceProtocol {
-  private _isCyclone = false;
+  private static DevInfos = new Map<string, VorzeType>([
+    [
+      "CycSA",
+      Object.assign(new VorzeType(), {
+        Name: "Vorze A10 Cyclone SA",
+        CommandType: VorzeCommand.Rotate,
+        DeviceType: 1,
+      }),
+    ],
+    [
+      "UFOSA",
+      Object.assign(new VorzeType(), {
+        Name: "Vorze UFO SA",
+        CommandType: VorzeCommand.Rotate,
+        DeviceType: 2,
+      }),
+    ],
+    [
+      "Bach smart",
+      Object.assign(new VorzeType(), {
+        Name: "Vorze Bach",
+        CommandType: VorzeCommand.Vibrate,
+        DeviceType: 6,
+      }),
+    ],
+  ]);
+
+  private _devInfo: VorzeType = new VorzeType();
+  private _clockwise = true;
+  private _speed = 0;
 
   public constructor(aDeviceImpl: IButtplugDeviceImpl) {
-    super(aDeviceImpl.Name === "CycSA" ? "Vorze A10 Cyclone" : "Vorze UFO SA", aDeviceImpl);
-    this._isCyclone = aDeviceImpl.Name === "CycSA";
+    super("Vorze", aDeviceImpl);
+
+    const tmpType  = VorzeA10Cyclone.DevInfos.get(aDeviceImpl.Name);
+    if (tmpType !== undefined) {
+      this._devInfo = tmpType;
+      this._name = this._devInfo.Name;
+    }
+
     this.MsgFuncs.set(Messages.StopDeviceCmd, this.HandleStopDeviceCmd);
-    this.MsgFuncs.set(Messages.VorzeA10CycloneCmd, this.HandleVorzeA10CycloneCmd);
-    this.MsgFuncs.set(Messages.RotateCmd, this.HandleRotateCmd);
+
+    if (this._devInfo.CommandType === VorzeCommand.Rotate) {
+      this.MsgFuncs.set(Messages.VorzeA10CycloneCmd, this.HandleVorzeA10CycloneCmd);
+      this.MsgFuncs.set(Messages.RotateCmd, this.HandleRotateCmd);
+    }
+
+    if (this._devInfo.CommandType === VorzeCommand.Vibrate) {
+      this.MsgFuncs.set(Messages.SingleMotorVibrateCmd, this.HandleSingleMotorVibrateCmd);
+      this.MsgFuncs.set(Messages.VibrateCmd, this.HandleVibrateCmd);
+    }
   }
 
   public get MessageSpecifications(): object {
+    if (this._devInfo.CommandType === VorzeCommand.Vibrate) {
+      return {
+        VibrateCmd: { FeatureCount: 1 },
+        SingleMotorVibrateCmd: {},
+        StopDeviceCmd: {},
+      };
+    }
+
     return {
       RotateCmd: { FeatureCount: 1 },
       VorzeA10CycloneCmd: {},
@@ -44,6 +106,11 @@ export class VorzeA10Cyclone extends ButtplugDeviceProtocol {
 
   private HandleStopDeviceCmd =
     async (aMsg: Messages.StopDeviceCmd): Promise<Messages.ButtplugMessage> => {
+      if (this._devInfo.CommandType === VorzeCommand.Vibrate) {
+        return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(0,
+                                                                                         aMsg.DeviceIndex,
+                                                                                         aMsg.Id));
+      }
       return await this.HandleVorzeA10CycloneCmd(new Messages.VorzeA10CycloneCmd(0,
                                                                                  false,
                                                                                  aMsg.DeviceIndex,
@@ -53,7 +120,27 @@ export class VorzeA10Cyclone extends ButtplugDeviceProtocol {
   private HandleVorzeA10CycloneCmd =
     async (aMsg: Messages.VorzeA10CycloneCmd): Promise<Messages.ButtplugMessage> => {
       const rawSpeed = (((aMsg.Clockwise ? 1 : 0) << 7) | aMsg.Speed) & 0xff;
-      await this._device.WriteValue(Buffer.from([this._isCyclone ? 0x01 : 0x02, 0x01, rawSpeed]));
+      await this._device.WriteValue(Buffer.from([this._devInfo.DeviceType, this._devInfo.CommandType, rawSpeed]));
+      return new Messages.Ok(aMsg.Id);
+    }
+
+  private HandleVibrateCmd = async (aMsg: Messages.VibrateCmd): Promise<Messages.ButtplugMessage> => {
+    if (aMsg.Speeds.length !== 1) {
+      throw new ButtplugDeviceException(`Vorze devices require VibrateCmd to have 1 speed commands, ` +
+        `${aMsg.Speeds.length} sent.`,
+        aMsg.Id);
+    }
+    return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(aMsg.Speeds[0].Speed,
+      aMsg.DeviceIndex,
+      aMsg.Id));
+  }
+
+  private HandleSingleMotorVibrateCmd =
+    async (aMsg: Messages.SingleMotorVibrateCmd): Promise<Messages.ButtplugMessage> => {
+      const newSpeed = Math.round(aMsg.Speed * 100);
+      if (newSpeed !== this._speed) {
+        await this._device.WriteValue(Buffer.from([this._devInfo.DeviceType, this._devInfo.CommandType, newSpeed]));
+      }
       return new Messages.Ok(aMsg.Id);
     }
 }

--- a/packages/buttplug/src/devices/protocols/Youcups.ts
+++ b/packages/buttplug/src/devices/protocols/Youcups.ts
@@ -1,0 +1,61 @@
+/*!
+ * Buttplug JS Source Code File - Visit https://buttplug.io for more info about
+ * the project. Licensed under the BSD 3-Clause license. See LICENSE file in the
+ * project root for full license information.
+ *
+ * @copyright Copyright (c) Nonpolynomial Labs LLC. All rights reserved.
+ */
+
+import * as Messages from "../../core/Messages";
+import { ButtplugDeviceException } from "../../core/Exceptions";
+import { ButtplugDeviceProtocol } from "../ButtplugDeviceProtocol";
+import { IButtplugDeviceImpl } from "../IButtplugDeviceImpl";
+import { ButtplugDeviceReadOptions } from "../ButtplugDeviceReadOptions";
+import { Endpoints } from "../Endpoints";
+
+export class Youcups extends ButtplugDeviceProtocol {
+
+  private _speed: number = 0;
+  private _sentVibration: boolean = false;
+
+  public constructor(aDeviceImpl: IButtplugDeviceImpl) {
+    super(`Youou ${aDeviceImpl.Name}` , aDeviceImpl);
+    this.MsgFuncs.set(Messages.StopDeviceCmd, this.HandleStopDeviceCmd);
+    this.MsgFuncs.set(Messages.SingleMotorVibrateCmd, this.HandleSingleMotorVibrateCmd);
+    this.MsgFuncs.set(Messages.VibrateCmd, this.HandleVibrateCmd);
+  }
+
+  public get MessageSpecifications(): object {
+    return {
+      VibrateCmd: { FeatureCount: 1 },
+      SingleMotorVibrateCmd: {},
+      StopDeviceCmd: {},
+    };
+  }
+
+  private HandleVibrateCmd = async (aMsg: Messages.VibrateCmd): Promise<Messages.ButtplugMessage> => {
+    if (aMsg.Speeds.length !== 1) {
+      throw new ButtplugDeviceException(`Youcups devices require VibrateCmd to have 1 speed commands, ` +
+                                        `${aMsg.Speeds.length} sent.`,
+                                        aMsg.Id);
+    }
+    return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(aMsg.Speeds[0].Speed,
+                                                                                     aMsg.DeviceIndex,
+                                                                                     aMsg.Id));
+  }
+
+  private HandleStopDeviceCmd = async (aMsg: Messages.StopDeviceCmd): Promise<Messages.ButtplugMessage> => {
+    return await this.HandleSingleMotorVibrateCmd(new Messages.SingleMotorVibrateCmd(0, aMsg.DeviceIndex, aMsg.Id));
+  }
+
+  private HandleSingleMotorVibrateCmd =
+    async (aMsg: Messages.SingleMotorVibrateCmd): Promise<Messages.ButtplugMessage> => {
+      const newSpeed = Math.round(aMsg.Speed * 8);
+      if (newSpeed !== this._speed || !this._sentVibration) {
+        this._sentVibration = true;
+        this._speed = newSpeed;
+        await this._device.WriteString(`$SYS,${newSpeed}?`);
+      }
+      return new Messages.Ok(aMsg.Id);
+    }
+}

--- a/packages/buttplug/src/server/managers/webbluetooth/WebBluetoothDeviceManager.ts
+++ b/packages/buttplug/src/server/managers/webbluetooth/WebBluetoothDeviceManager.ts
@@ -53,7 +53,7 @@ export class WebBluetoothDeviceManager extends EventEmitter implements IDeviceSu
       filters.optionalServices = [...filters.optionalServices, ...config.Services.keys()];
     }
 
-    this._logger.Trace("Bluetooth filter set: " + filters);
+    this._logger.Trace("Bluetooth filter set: " + JSON.stringify(filters));
 
     // At some point, we should use navigator.bluetooth.getAvailability() to
     // check whether we have a radio to use. However, no browser currently


### PR DESCRIPTION
This change ports missing protocols from C# to JS:
* LiBo/Sistalk
* MagicMotion (fixes #114)
* Youcups (fixes #117)
* Vorze Bach

There's something odd with the device-config not merging nicely, but I think that should be corrected elsewhere and the change in this PR rebased out.

Still need to write tests too.