### PR TITLE
Purge Buttplug Server CLI from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ write code for!
 - [Buttplug Node Websockets](packages/buttplug-node-websockets)
   - [ws](https://github.com/websockets/ws) based Websocket connectors
     for native buttplug clients and servers.
-- [Buttplug Server CLI](packages/buttplug-server-cli)
-  - Command Line server for running native node servers.
   
 ## Applications Using Buttplug-js
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "workspaces": [
     "packages/buttplug",
     "packages/buttplug-node-bluetoothle-manager",
-    "packages/buttplug-node-websockets",
-    "packages/buttplug-server-cli"
+    "packages/buttplug-node-websockets"
   ],
   "devDependencies": {
     "@types/commander": "^2.12.2",


### PR DESCRIPTION
I don't quite know why you got rid of packages/buttplug-server-cli but it's been a 404 for a few months now it seems, this removes the remnants of it