### PR TITLE
fix: Correct a type error in ForwardedDeviceProtocol

### DIFF
--- a/packages/buttplug/src/server/managers/forwardeddevices/ForwardedDeviceProtocol.ts
+++ b/packages/buttplug/src/server/managers/forwardeddevices/ForwardedDeviceProtocol.ts
@@ -16,7 +16,7 @@ export class ForwardedDeviceProtocol extends ButtplugDeviceProtocol {
   public constructor(aDeviceImpl: IButtplugDeviceImpl,
                      private _actualDeviceIndex: number,
                      private _messageSpecs: object,
-                     private _clientSendClosure: (aMsg: Messages.ButtplugMessage) => Promise<Messages.ButtplugMessage>) {
+                     private _clientSendClosure: (aMsg: Messages.ButtplugDeviceMessage) => Promise<Messages.ButtplugMessage>) {
     super(`${aDeviceImpl.Name}` , aDeviceImpl);
   }
 
@@ -29,13 +29,13 @@ export class ForwardedDeviceProtocol extends ButtplugDeviceProtocol {
   }
 
   // Override the base protocol ParseMessage, because we'll never actually handle our own messages.
-  public ParseMessage = async (aMsg: Messages.ButtplugDeviceMessage): Promise<Messages.ButtplugMessage> => {
-    if (!this.MessageSpecifications.hasOwnProperty(aMsg.Type.name)) {
+  public ParseMessage = async (aMsg: Messages.ButtplugMessage): Promise<Messages.ButtplugMessage> => {
+    if (!(aMsg instanceof Messages.ButtplugDeviceMessage) || !this.MessageSpecifications.hasOwnProperty(aMsg.Type.name)) {
       throw new ButtplugMessageException(`${this._name} cannot handle message of type ${aMsg.Type.name}`, aMsg.Id);
     }
     // Swap out the device index so we send to the correct device on the other end.
-    aMsg.DeviceIndex = this._actualDeviceIndex;
+    (aMsg as Messages.ButtplugDeviceMessage).DeviceIndex = this._actualDeviceIndex;
     // We can forward this message on to the client to run.
-    return await this._clientSendClosure(aMsg);
+    return await this._clientSendClosure(aMsg as Messages.ButtplugDeviceMessage);
   }
 }


### PR DESCRIPTION
```
node_modules/buttplug/dist/main/src/server/managers/forwardeddevices/ForwardedDeviceProtocol.d.ts(18,5): error TS2416: Property 'ParseMessage' in type 'ForwardedDeviceProtocol' is not assignable to the same property in base type 'ButtplugDeviceProtocol'.
  Type '(aMsg: ButtplugDeviceMessage) => Promise<ButtplugMessage>' is not assignable to type '(aMsg: ButtplugMessage) => Promise<ButtplugMessage>'.
    Types of parameters 'aMsg' and 'aMsg' are incompatible.
      Property 'DeviceIndex' is missing in type 'ButtplugMessage' but required in type 'ButtplugDeviceMessage'.
```

This type mismatch causes issues when compiling the typescript to javascript.