### PR TITLE
#257 - add exception handler for error events

### DIFF
--- a/js/tests/test-websocketclient.ts
+++ b/js/tests/test-websocketclient.ts
@@ -79,4 +79,13 @@ describe("Websocket Client Tests", () => {
     });
     await expect(bp.stopAllDevices()).rejects.toBeInstanceOf(ButtplugMessageError);
   });
+
+  it("Should throw Error on TCPCONNECTREFUSED", async () => {
+    const connector = new ButtplugBrowserWebsocketClientConnector("ws://localhost:31000")
+    try {
+      await connector.connect();
+    } catch (e) {
+      expect(e).toBeDefined();
+    }
+  });
 });


### PR DESCRIPTION
Changes made to resolve issue #257 

- Add Error Event Listener to the Websocket that returns any error occuring during the Connection Process via the reject function
- Add Testcase to see if a catchable error is thrown if there is no server available
- Return promise directly
- Return errors using the reject function