### PR TITLE
Clear device list on disconnect

### DIFF
--- a/js/src/client/Client.ts
+++ b/js/src/client/Client.ts
@@ -71,6 +71,7 @@ export class ButtplugClient extends EventEmitter {
 
   public disconnect = async () => {
     this._logger.Debug('ButtplugClient: Disconnect called');
+    this._devices.clear();
     this.checkConnector();
     await this.shutdownConnection();
     await this._connector!.disconnect();


### PR DESCRIPTION
Placed before any networking so that if the server is already disconnected, we still clear the list. Not sure if there's any edge case where it could stay connected after a `disconnect()` call, but if so, this might need more complicated logic.