### PR TITLE
fix: resolve #295 — Web example Buttplug <> buttplug

### DIFF
--- a/js/examples/web/application-example.js
+++ b/js/examples/web/application-example.js
@@ -17,7 +17,7 @@ async function runApplicationExample() {
 
   // Step 1: Create a client
   // The client name identifies your application to the server.
-  const client = new Buttplug.ButtplugClient("My Buttplug Application");
+  const client = new buttplug.ButtplugClient("My Buttplug Application");
 
   // Step 2: Set up event handlers
   // Always do this BEFORE connecting to avoid missing events.
@@ -36,12 +36,12 @@ async function runApplicationExample() {
   // Step 3: Connect to the server
   console.log("Connecting to Intiface Central...");
   try {
-    const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector(
+    const connector = new buttplug.ButtplugBrowserWebsocketClientConnector(
       "ws://127.0.0.1:12345"
     );
     await client.connect(connector);
   } catch (e) {
-    if (e instanceof Buttplug.ButtplugClientConnectorException) {
+    if (e instanceof buttplug.ButtplugClientConnectorException) {
       alert(
         "Could not connect to Intiface Central!\n\n" +
         "Make sure Intiface Central is running and the server is started.\n" +

--- a/js/examples/web/async-example.js
+++ b/js/examples/web/async-example.js
@@ -10,7 +10,7 @@
 async function runAsyncExample() {
   console.log("Running async example");
 
-  const client = new Buttplug.ButtplugClient("Async Example");
+  const client = new buttplug.ButtplugClient("Async Example");
 
   // Events in buttplug-js use EventEmitter3.
   // You can use addListener or on to subscribe to events.
@@ -21,9 +21,9 @@ async function runAsyncExample() {
     console.log(`[Event] Device added: ${device.name}`);
 
     // You can interact with the device in the event handler
-    if (device.hasOutput(Buttplug.OutputType.Vibrate)) {
+    if (device.hasOutput(buttplug.OutputType.Vibrate)) {
       console.log("  Sending welcome vibration...");
-      await device.runOutput(Buttplug.DeviceOutput.Vibrate.percent(0.25));
+      await device.runOutput(buttplug.DeviceOutput.Vibrate.percent(0.25));
       await new Promise(r => setTimeout(r, 200));
       await device.stop();
     }
@@ -52,7 +52,7 @@ async function runAsyncExample() {
 
   // Connect asynchronously - this may take time due to network
   console.log("Connecting to server...");
-  const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
+  const connector = new buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
   await client.connect(connector);
   console.log("Connected!");
 

--- a/js/examples/web/device-control-example.js
+++ b/js/examples/web/device-control-example.js
@@ -7,8 +7,8 @@
 // <script src="https://cdn.jsdelivr.net/npm/buttplug@4.0.0/dist/web/buttplug.min.js"></script>
 
 async function runDeviceControlExample() {
-  const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
-  const client = new Buttplug.ButtplugClient("Device Control Example");
+  const connector = new buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
+  const client = new buttplug.ButtplugClient("Device Control Example");
 
   // Set up event handlers before connecting
   client.addListener("deviceadded", async (device) => {
@@ -21,7 +21,7 @@ async function runDeviceControlExample() {
     }
 
     // Check if device supports vibration using v4 API
-    if (!device.hasOutput(Buttplug.OutputType.Vibrate)) {
+    if (!device.hasOutput(buttplug.OutputType.Vibrate)) {
       console.log("Device does not support vibration, skipping control demo.");
       return;
     }
@@ -31,7 +31,7 @@ async function runDeviceControlExample() {
     try {
       // Use the v4 command builder API
       console.log("Vibrating at 100%...");
-      await device.runOutput(Buttplug.DeviceOutput.Vibrate.percent(1.0));
+      await device.runOutput(buttplug.DeviceOutput.Vibrate.percent(1.0));
 
       await new Promise(r => setTimeout(r, 1000));
 
@@ -44,13 +44,13 @@ async function runDeviceControlExample() {
       await device.stop();
     } catch (e) {
       console.log("Error sending command:", e);
-      if (e instanceof Buttplug.ButtplugDeviceError) {
+      if (e instanceof buttplug.ButtplugDeviceError) {
         console.log("This is a device error - device may have disconnected.");
       }
     }
 
     // Check for battery support using v4 API
-    if (device.hasInput(Buttplug.InputType.Battery)) {
+    if (device.hasInput(buttplug.InputType.Battery)) {
       try {
         const level = await device.battery();
         console.log(`${device.name} Battery Level: ${(level * 100).toFixed(0)}%`);
@@ -60,16 +60,16 @@ async function runDeviceControlExample() {
     }
 
     // Demonstrate other output types if available
-    if (device.hasOutput(Buttplug.OutputType.Rotate)) {
+    if (device.hasOutput(buttplug.OutputType.Rotate)) {
       console.log("Device supports rotation. Rotating at 50%...");
-      await device.runOutput(Buttplug.DeviceOutput.Rotate.percent(0.5));
+      await device.runOutput(buttplug.DeviceOutput.Rotate.percent(0.5));
       await new Promise(r => setTimeout(r, 1000));
       await device.stop();
     }
 
-    if (device.hasOutput(Buttplug.OutputType.Position)) {
+    if (device.hasOutput(buttplug.OutputType.Position)) {
       console.log("Device supports position control. Moving...");
-      await device.runOutput(Buttplug.DeviceOutput.PositionWithDuration.percent(1.0, 500));
+      await device.runOutput(buttplug.DeviceOutput.PositionWithDuration.percent(1.0, 500));
       await new Promise(r => setTimeout(r, 1000));
       await device.runOutput(Buttplug.DeviceOutput.PositionWithDuration.percent(0.0, 500));
     }

--- a/js/examples/web/device-enumeration-example.js
+++ b/js/examples/web/device-enumeration-example.js
@@ -7,7 +7,7 @@
 // <script src="https://cdn.jsdelivr.net/npm/buttplug@4.0.0/dist/web/buttplug.min.js"></script>
 
 async function runDeviceEnumerationExample() {
-  const client = new Buttplug.ButtplugClient("Device Enumeration Example");
+  const client = new buttplug.ButtplugClient("Device Enumeration Example");
 
   // Set up event handlers BEFORE connecting.
   // This ensures we don't miss any events, including devices
@@ -33,7 +33,7 @@ async function runDeviceEnumerationExample() {
   });
 
   // Connect to the server (requires Intiface Central running)
-  const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("ws://localhost:12345");
+  const connector = new buttplug.ButtplugBrowserWebsocketClientConnector("ws://localhost:12345");
 
   console.log("Connecting...");
   await client.connect(connector);

--- a/js/examples/web/device-info-example.js
+++ b/js/examples/web/device-info-example.js
@@ -20,14 +20,14 @@ function printDeviceInfo(device) {
 
   // Collect output capabilities
   const outputTypes = [];
-  if (device.hasOutput(Buttplug.OutputType.Vibrate)) outputTypes.push("Vibrate");
-  if (device.hasOutput(Buttplug.OutputType.Rotate)) outputTypes.push("Rotate");
-  if (device.hasOutput(Buttplug.OutputType.Oscillate)) outputTypes.push("Oscillate");
-  if (device.hasOutput(Buttplug.OutputType.Position)) outputTypes.push("Position");
-  if (device.hasOutput(Buttplug.OutputType.Constrict)) outputTypes.push("Constrict");
-  if (device.hasOutput(Buttplug.OutputType.Inflate)) outputTypes.push("Inflate");
-  if (device.hasOutput(Buttplug.OutputType.Temperature)) outputTypes.push("Temperature");
-  if (device.hasOutput(Buttplug.OutputType.Led)) outputTypes.push("LED");
+  if (device.hasOutput(buttplug.OutputType.Vibrate)) outputTypes.push("Vibrate");
+  if (device.hasOutput(buttplug.OutputType.Rotate)) outputTypes.push("Rotate");
+  if (device.hasOutput(buttplug.OutputType.Oscillate)) outputTypes.push("Oscillate");
+  if (device.hasOutput(buttplug.OutputType.Position)) outputTypes.push("Position");
+  if (device.hasOutput(buttplug.OutputType.Constrict)) outputTypes.push("Constrict");
+  if (device.hasOutput(buttplug.OutputType.Inflate)) outputTypes.push("Inflate");
+  if (device.hasOutput(buttplug.OutputType.Temperature)) outputTypes.push("Temperature");
+  if (device.hasOutput(buttplug.OutputType.Led)) outputTypes.push("LED");
 
   if (outputTypes.length > 0) {
     console.log(`\nOutput Capabilities: ${outputTypes.join(", ")}`);
@@ -35,10 +35,10 @@ function printDeviceInfo(device) {
 
   // Collect input capabilities
   const inputTypes = [];
-  if (device.hasInput(Buttplug.InputType.Battery)) inputTypes.push("Battery");
-  if (device.hasInput(Buttplug.InputType.RSSI)) inputTypes.push("RSSI");
-  if (device.hasInput(Buttplug.InputType.Button)) inputTypes.push("Button");
-  if (device.hasInput(Buttplug.InputType.Pressure)) inputTypes.push("Pressure");
+  if (device.hasInput(buttplug.InputType.Battery)) inputTypes.push("Battery");
+  if (device.hasInput(buttplug.InputType.RSSI)) inputTypes.push("RSSI");
+  if (device.hasInput(buttplug.InputType.Button)) inputTypes.push("Button");
+  if (device.hasInput(buttplug.InputType.Pressure)) inputTypes.push("Pressure");
 
   if (inputTypes.length > 0) {
     console.log(`Input Capabilities: ${inputTypes.join(", ")}`);
@@ -68,10 +68,10 @@ function printDeviceInfo(device) {
 }
 
 async function runDeviceInfoExample() {
-  const client = new Buttplug.ButtplugClient("Device Info Example");
+  const client = new buttplug.ButtplugClient("Device Info Example");
 
   // Connect to the server
-  const connector = new Buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
+  const connector = new buttplug.ButtplugBrowserWebsocketClientConnector("ws://127.0.0.1:12345");
 
   console.log("Connecting...");
   await client.connect(connector);


### PR DESCRIPTION
## Summary

fix: resolve #295 — Web example Buttplug <> buttplug

## Problem

**Severity**: `High` | **File**: `js/examples/web/device-enumeration-example.js`

Same issue - uses `Buttplug` but package exports `buttplug`.

## Solution

Replace all occurrences of `Buttplug.` with `buttplug.` throughout the file.

## Changes

- `js/examples/web/device-enumeration-example.js` (modified)
- `js/examples/web/async-example.js` (modified)
- `js/examples/web/application-example.js` (modified)
- `js/examples/web/device-control-example.js` (modified)
- `js/examples/web/device-info-example.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v5.8.1*